### PR TITLE
Initialize Android note app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+build/
+app/build/
+local.properties
+*.iml

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,50 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+    id("com.google.dagger.hilt.android")
+    kotlin("kapt")
+}
+
+android {
+    namespace = "com.motorola.edgenotes"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.motorola.edgenotes"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "0.1"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.11"
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(platform("androidx.compose:compose-bom:2024.09.01"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
+    implementation("androidx.activity:activity-compose:1.9.2")
+    implementation("androidx.navigation:navigation-compose:2.8.0")
+
+    implementation("androidx.room:room-ktx:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
+
+    implementation("com.google.dagger:hilt-android:2.51.1")
+    kapt("com.google.dagger:hilt-android-compiler:2.51.1")
+
+    testImplementation("junit:junit:4.13.2")
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.motorola.edgenotes">
+
+    <application
+        android:name=".EdgeNotesApp"
+        android:label="EdgeNotes"
+        android:icon="@mipmap/ic_launcher"
+        android:theme="@style/Theme.EdgeNotes">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/com/motorola/edgenotes/EdgeNotesApp.kt
+++ b/app/src/main/java/com/motorola/edgenotes/EdgeNotesApp.kt
@@ -1,0 +1,7 @@
+package com.motorola.edgenotes
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class EdgeNotesApp : Application()

--- a/app/src/main/java/com/motorola/edgenotes/MainActivity.kt
+++ b/app/src/main/java/com/motorola/edgenotes/MainActivity.kt
@@ -1,0 +1,16 @@
+package com.motorola.edgenotes
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            NotesApp()
+        }
+    }
+}

--- a/app/src/main/java/com/motorola/edgenotes/NotesApp.kt
+++ b/app/src/main/java/com/motorola/edgenotes/NotesApp.kt
@@ -1,0 +1,24 @@
+package com.motorola.edgenotes
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.motorola.edgenotes.presentation.notes.detail.NoteDetailScreen
+import com.motorola.edgenotes.presentation.notes.list.NotesListScreen
+
+@Composable
+fun NotesApp() {
+    MaterialTheme {
+        val navController = rememberNavController()
+        NavHost(navController = navController, startDestination = "list") {
+            composable("list") {
+                NotesListScreen(onAddNote = { navController.navigate("detail") })
+            }
+            composable("detail") {
+                NoteDetailScreen()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/motorola/edgenotes/data/local/NoteDao.kt
+++ b/app/src/main/java/com/motorola/edgenotes/data/local/NoteDao.kt
@@ -1,0 +1,20 @@
+package com.motorola.edgenotes.data.local
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface NoteDao {
+    @Query("SELECT * FROM notes ORDER BY timestamp DESC")
+    fun getNotes(): Flow<List<NoteEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertNote(note: NoteEntity)
+
+    @Query("DELETE FROM notes WHERE id = :id")
+    suspend fun deleteNote(id: Long)
+}

--- a/app/src/main/java/com/motorola/edgenotes/data/local/NoteDatabase.kt
+++ b/app/src/main/java/com/motorola/edgenotes/data/local/NoteDatabase.kt
@@ -1,0 +1,9 @@
+package com.motorola.edgenotes.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(entities = [NoteEntity::class], version = 1)
+abstract class NoteDatabase : RoomDatabase() {
+    abstract fun noteDao(): NoteDao
+}

--- a/app/src/main/java/com/motorola/edgenotes/data/local/NoteEntity.kt
+++ b/app/src/main/java/com/motorola/edgenotes/data/local/NoteEntity.kt
@@ -1,0 +1,12 @@
+package com.motorola.edgenotes.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "notes")
+data class NoteEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
+    val title: String,
+    val content: String,
+    val timestamp: Long
+)

--- a/app/src/main/java/com/motorola/edgenotes/data/repository/NoteRepositoryImpl.kt
+++ b/app/src/main/java/com/motorola/edgenotes/data/repository/NoteRepositoryImpl.kt
@@ -1,0 +1,40 @@
+package com.motorola.edgenotes.data.repository
+
+import com.motorola.edgenotes.data.local.NoteDao
+import com.motorola.edgenotes.data.local.NoteEntity
+import com.motorola.edgenotes.domain.model.Note
+import com.motorola.edgenotes.domain.repository.NoteRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class NoteRepositoryImpl @Inject constructor(
+    private val dao: NoteDao
+) : NoteRepository {
+    override fun getNotes(): Flow<List<Note>> =
+        dao.getNotes().map { entities ->
+            entities.map { it.toNote() }
+        }
+
+    override suspend fun insertNote(note: Note) {
+        dao.insertNote(note.toEntity())
+    }
+
+    override suspend fun deleteNote(id: Long) {
+        dao.deleteNote(id)
+    }
+}
+
+private fun NoteEntity.toNote() = Note(
+    id = id,
+    title = title,
+    content = content,
+    timestamp = timestamp
+)
+
+private fun Note.toEntity() = NoteEntity(
+    id = id,
+    title = title,
+    content = content,
+    timestamp = timestamp
+)

--- a/app/src/main/java/com/motorola/edgenotes/di/DatabaseModule.kt
+++ b/app/src/main/java/com/motorola/edgenotes/di/DatabaseModule.kt
@@ -1,0 +1,26 @@
+package com.motorola.edgenotes.di
+
+import android.content.Context
+import androidx.room.Room
+import com.motorola.edgenotes.data.local.NoteDatabase
+import com.motorola.edgenotes.data.repository.NoteRepositoryImpl
+import com.motorola.edgenotes.domain.repository.NoteRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): NoteDatabase =
+        Room.databaseBuilder(context, NoteDatabase::class.java, "notes.db").build()
+
+    @Provides
+    @Singleton
+    fun provideRepository(db: NoteDatabase): NoteRepository = NoteRepositoryImpl(db.noteDao())
+}

--- a/app/src/main/java/com/motorola/edgenotes/domain/model/Note.kt
+++ b/app/src/main/java/com/motorola/edgenotes/domain/model/Note.kt
@@ -1,0 +1,8 @@
+package com.motorola.edgenotes.domain.model
+
+data class Note(
+    val id: Long = 0L,
+    val title: String,
+    val content: String,
+    val timestamp: Long
+)

--- a/app/src/main/java/com/motorola/edgenotes/domain/repository/NoteRepository.kt
+++ b/app/src/main/java/com/motorola/edgenotes/domain/repository/NoteRepository.kt
@@ -1,0 +1,10 @@
+package com.motorola.edgenotes.domain.repository
+
+import com.motorola.edgenotes.domain.model.Note
+import kotlinx.coroutines.flow.Flow
+
+interface NoteRepository {
+    fun getNotes(): Flow<List<Note>>
+    suspend fun insertNote(note: Note)
+    suspend fun deleteNote(id: Long)
+}

--- a/app/src/main/java/com/motorola/edgenotes/domain/usecase/AddNoteUseCase.kt
+++ b/app/src/main/java/com/motorola/edgenotes/domain/usecase/AddNoteUseCase.kt
@@ -1,0 +1,13 @@
+package com.motorola.edgenotes.domain.usecase
+
+import com.motorola.edgenotes.domain.model.Note
+import com.motorola.edgenotes.domain.repository.NoteRepository
+import javax.inject.Inject
+
+class AddNoteUseCase @Inject constructor(
+    private val repository: NoteRepository
+) {
+    suspend operator fun invoke(note: Note) {
+        repository.insertNote(note)
+    }
+}

--- a/app/src/main/java/com/motorola/edgenotes/domain/usecase/GetNotesUseCase.kt
+++ b/app/src/main/java/com/motorola/edgenotes/domain/usecase/GetNotesUseCase.kt
@@ -1,0 +1,12 @@
+package com.motorola.edgenotes.domain.usecase
+
+import com.motorola.edgenotes.domain.model.Note
+import com.motorola.edgenotes.domain.repository.NoteRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetNotesUseCase @Inject constructor(
+    private val repository: NoteRepository
+) {
+    operator fun invoke(): Flow<List<Note>> = repository.getNotes()
+}

--- a/app/src/main/java/com/motorola/edgenotes/presentation/notes/detail/NoteDetailScreen.kt
+++ b/app/src/main/java/com/motorola/edgenotes/presentation/notes/detail/NoteDetailScreen.kt
@@ -1,0 +1,36 @@
+package com.motorola.edgenotes.presentation.notes.detail
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun NoteDetailScreen(
+    viewModel: NoteDetailViewModel = hiltViewModel()
+) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = viewModel.title,
+            onValueChange = viewModel::onTitleChange,
+            placeholder = { Text("Title") }
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = viewModel.content,
+            onValueChange = viewModel::onContentChange,
+            placeholder = { Text("Content") }
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = viewModel::saveNote) {
+            Text("Save")
+        }
+    }
+}

--- a/app/src/main/java/com/motorola/edgenotes/presentation/notes/detail/NoteDetailViewModel.kt
+++ b/app/src/main/java/com/motorola/edgenotes/presentation/notes/detail/NoteDetailViewModel.kt
@@ -1,0 +1,42 @@
+package com.motorola.edgenotes.presentation.notes.detail
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.motorola.edgenotes.domain.model.Note
+import com.motorola.edgenotes.domain.usecase.AddNoteUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NoteDetailViewModel @Inject constructor(
+    private val addNote: AddNoteUseCase
+) : ViewModel() {
+    var title by mutableStateOf("")
+        private set
+    var content by mutableStateOf("")
+        private set
+
+    fun onTitleChange(value: String) {
+        title = value
+    }
+
+    fun onContentChange(value: String) {
+        content = value
+    }
+
+    fun saveNote() {
+        viewModelScope.launch {
+            addNote(
+                Note(
+                    title = title,
+                    content = content,
+                    timestamp = System.currentTimeMillis()
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/motorola/edgenotes/presentation/notes/list/NotesListScreen.kt
+++ b/app/src/main/java/com/motorola/edgenotes/presentation/notes/list/NotesListScreen.kt
@@ -1,0 +1,38 @@
+package com.motorola.edgenotes.presentation.notes.list
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun NotesListScreen(
+    onAddNote: () -> Unit,
+    viewModel: NotesListViewModel = hiltViewModel()
+) {
+    val notes by viewModel.notes.collectAsState()
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAddNote) {
+                Icon(Icons.Filled.Add, contentDescription = "Add")
+            }
+        }
+    ) { padding ->
+        LazyColumn(modifier = Modifier.padding(padding)) {
+            items(notes) { note ->
+                Text(text = note.title, modifier = Modifier.padding(16.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/motorola/edgenotes/presentation/notes/list/NotesListViewModel.kt
+++ b/app/src/main/java/com/motorola/edgenotes/presentation/notes/list/NotesListViewModel.kt
@@ -1,0 +1,22 @@
+package com.motorola.edgenotes.presentation.notes.list
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.motorola.edgenotes.domain.model.Note
+import com.motorola.edgenotes.domain.usecase.GetNotesUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class NotesListViewModel @Inject constructor(
+    getNotesUseCase: GetNotesUseCase
+) : ViewModel() {
+    val notes: StateFlow<List<Note>> = getNotesUseCase().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = emptyList()
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">EdgeNotes</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.EdgeNotes" parent="Theme.Material3.DayNight.NoActionBar">
+        <!-- Customize theme here -->
+    </style>
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("com.android.application") version "8.3.2" apply false
+    kotlin("android") version "1.9.24" apply false
+    id("com.google.dagger.hilt.android") version "2.51.1" apply false
+    kotlin("kapt") version "1.9.24" apply false
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "EdgeNotes"
+include(":app")


### PR DESCRIPTION
## Summary
- scaffold Android note app with Jetpack Compose, Hilt, Room, and navigation
- add domain, data, and presentation layers for basic note list and detail editing
- configure Gradle build with required plugins and dependencies

## Testing
- `gradle tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_68ba9e903f808322b6f8816c4015e197